### PR TITLE
Update gh-pages with new dataset, some story line, and some removed code that will go into shell genomics

### DIFF
--- a/_episodes/00-quality-control.md
+++ b/_episodes/00-quality-control.md
@@ -308,7 +308,7 @@ will move these
 output files into a new directory within our `results/` directory.
 
 ~~~
-$ mkdir ~/dc_workshop/results/fastqc_untrimmed_reads
+$ mkdir -p ~/dc_workshop/results/fastqc_untrimmed_reads
 $ mv *.zip ~/dc_workshop/results/fastqc_untrimmed_reads/
 $ mv *.html ~/dc_workshop/results/fastqc_untrimmed_reads/
 ~~~

--- a/_episodes/00-quality-control.md
+++ b/_episodes/00-quality-control.md
@@ -45,9 +45,9 @@ We are studying a population of *Escherichia coli* (designated Ara-3), which wer
 
 The data are paired-end, so we will download two files for each sample. We will use the [European Nucleotide Archive](https://www.ebi.ac.uk/ena) to get our data. The ENA "provides a comprehensive record of the world's nucleotide sequencing information, covering raw sequencing data, sequence assembly information and functional annotation." The ENA also provides sequencing data in the fastq format, an important format for sequencing reads that we will be learning about today. 
 
-To download the data, run the following commands:
+To download the data, run the commands below. It will take about 10 minutes to download the files.
 ~~~
-mkdir ~/dc_workshop/data/untrimmed_fastq/
+mkdir -p ~/dc_workshop/data/untrimmed_fastq/
 cd ~/dc_workshop/data/untrimmed_fastq
 
 curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/004/SRR2589044/SRR2589044_1.fastq.gz

--- a/_episodes/00-quality-control.md
+++ b/_episodes/00-quality-control.md
@@ -37,16 +37,43 @@ makes this feasible. Standards ensure that data is stored in a way that is gener
 within the community. The tools that are used to analyze data at different stages of the workflow are therefore 
 built under the assumption that the data will be provided in a specific format.  
 
+# Starting with Data
+
+Often times, the first step in a bioinformatics workflow is getting the data you want to work with onto a computer where you can work with it. If you have sequenced your own data, the sequencing center will usually provide you with a link that you can use to download your data. Today we will be working with publicly available sequencing data.
+
+We are studying a population of *Escherichia coli* (designated Ara-3), which were propagated for more than 50,000 generations in a glucose-limited minimal medium. We will be working with three samples from this experiment, one from 5,000 generations, one from 15,000 generations, and one from 50,000 generations. The population changed substantially during the course of the experiment, and we will be exploring how with our variant calling workflow. 
+
+The data are paired-end, so we will download two files for each sample. We will use the [European Nucleotide Archive](https://www.ebi.ac.uk/ena) to get our data. The ENA "provides a comprehensive record of the world's nucleotide sequencing information, covering raw sequencing data, sequence assembly information and functional annotation." The ENA also provides sequencing data in the fastq format, an important format for sequencing reads that we will be learning about today. 
+
+To download the data, run the following commands:
+~~~
+mkdir ~/dc_workshop/data/untrimmed_fastq/
+cd ~/dc_workshop/data/untrimmed_fastq
+
+curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/004/SRR2589044/SRR2589044_1.fastq.gz
+curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/004/SRR2589044/SRR2589044_2.fastq.gz
+curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/003/SRR2584863/SRR2584863_1.fastq.gz
+curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/003/SRR2584863/SRR2584863_2.fastq.gz
+curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_1.fastq.gz
+curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_2.fastq.gz
+~~~
+{: .bash}
+
+The data comes in a compressed format, which is why there is a `.gz` at the end of the file names. This makes it faster to transfer, and allows it to take up less space on our computer. Let's unzip one of the files so that we can look at the fastq format.
+
+~~~
+gunzip SRR2584863_1.fastq
+~~~
+{: .bash}
 
 # Quality Control
 
-The first step in the variant calling workflow is to take the FASTQ files received from the sequencing facility
-and assess the quality of the sequence reads. 
+We will now assess the quality of the sequence reads contained in our fastq files. 
 
 ![workflow_qc](../img/var_calling_workflow_qc.png)
 ## Details on the FASTQ format
 
-Although it looks complicated (and it is), it's easy to understand the
+Although it looks complicated (and it is), we can understand the
 [fastq](https://en.wikipedia.org/wiki/FASTQ_format) format with a little decoding. Some rules about the format
 include...
 
@@ -58,37 +85,34 @@ include...
 |4|Has a string of characters which represent the quality scores; must have same number of characters as line 2|
 
 We can view the first complete read in one of the files our dataset by using `head` to look at
-the first four lines.
+the first four lines. 
 
 ~~~
-$ head -n4 SRR098026.fastq
+$ head -n 4 SRR2584863_1.fastq
 ~~~
 {: .bash}
 
 ~~~
-@SRR098026.1 HWUSI-EAS1599_1:2:1:0:968 length=35
-NNNNNNNNNNNNNNNNCNNNNNNNNNNNNNNNNNN
-+SRR098026.1 HWUSI-EAS1599_1:2:1:0:968 length=35
-!!!!!!!!!!!!!!!!#!!!!!!!!!!!!!!!!!!
+@SRR2584863.1 HWI-ST957:244:H73TDADXX:1:1101:4712:2181/1
+TTCACATCCTGACCATTCAGTTGAGCAAAATAGTTCTTCAGTGCCTGTTTAACCGAGTCACGCAGGGGTTTTTGGGTTACCTGATCCTGAGAGTTAACGGTAGAAACGGTCAGTACGTCAGAATTTACGCGTTGTTCGAACATAGTTCTG
++
+CCCFFFFFGHHHHJIJJJJIJJJIIJJJJIIIJJGFIIIJEDDFEGGJIFHHJIJJDECCGGEGIIJFHFFFACD:BBBDDACCCCAA@@CA@C>C3>@5(8&>C:9?8+89<4(:83825C(:A#########################
 ~~~
 {: .output}
 
-All but one of the nucleotides in this read are unknown (`N`). This is a pretty bad read!
-
 Line 4 shows the quality for each nucleotide in the read. Quality is interpreted as the 
 probability of an incorrect base call (e.g. 1 in 10) or, equivalently, the base call 
-accuracy (eg 90%). To make it possible to line up each individual nucleotide with its quality
+accuracy (e.g. 90%). To make it possible to line up each individual nucleotide with its quality
 score, the numerical score is converted into a code where each individual character 
 represents the numerical quality score for an individual nucleotide. For example, in the line
 above, the quality score line is: 
 
 ~~~
-!!!!!!!!!!!!!!!!#!!!!!!!!!!!!!!!!!!
+CCCFFFFFGHHHHJIJJJJIJJJIIJJJJIIIJJGFIIIJEDDFEGGJIFHHJIJJDECCGGEGIIJFHFFFACD:BBBDDACCCCAA@@CA@C>C3>@5(8&>C:9?8+89<4(:83825C(:A#########################
 ~~~
 {: .output}
 
-The `#` character and each of the `!` characters represent the encoded quality for an 
-individual nucleotide. The numerical value assigned to each of these characters depends on the 
+The numerical value assigned to each of these characters depends on the 
 sequencing platform that generated the reads. The sequencing machine used to generate our data 
 uses the standard Sanger quality PHRED score encoding, using by Illumina version 1.8 onwards.
 Each character is assigned a quality score between 0 and 40 as shown in the chart below.
@@ -109,58 +133,43 @@ much signal was captured for the base incorporation.
 Looking back at our read: 
 
 ~~~
-@SRR098026.1 HWUSI-EAS1599_1:2:1:0:968 length=35
-NNNNNNNNNNNNNNNNCNNNNNNNNNNNNNNNNNN
-+SRR098026.1 HWUSI-EAS1599_1:2:1:0:968 length=35
-!!!!!!!!!!!!!!!!#!!!!!!!!!!!!!!!!!!
+@SRR2584863.1 HWI-ST957:244:H73TDADXX:1:1101:4712:2181/1
+TTCACATCCTGACCATTCAGTTGAGCAAAATAGTTCTTCAGTGCCTGTTTAACCGAGTCACGCAGGGGTTTTTGGGTTACCTGATCCTGAGAGTTAACGGTAGAAACGGTCAGTACGTCAGAATTTACGCGTTGTTCGAACATAGTTCTG
++
+CCCFFFFFGHHHHJIJJJJIJJJIIJJJJIIIJJGFIIIJEDDFEGGJIFHHJIJJDECCGGEGIIJFHFFFACD:BBBDDACCCCAA@@CA@C>C3>@5(8&>C:9?8+89<4(:83825C(:A#########################
 ~~~
 {: .output}
 
-we can now see that the quality of each of the `N`s is 0 and the quality of the only
-nucleotide call (`C`) is also very poor (`#` = a quality score of 2). This is indeed a very
-bad read. 
+we can now see that there are a range of quality score, but that the end of the sequence
+very poor (`#` = a quality score of 2). 
 
 > ## Exercise
 > 
-> What is the last read in the `SRR098026.fastq` file? How confident
+> What is the last read in the `SRR2584863_1.fastq ` file? How confident
 > are you in this read? 
 > 
 >> ## Solution
 >> ~~~
->> $ tail -n4 SRR098026.fastq
+>> $ tail -n 4 SRR2584863_1.fastq 
 >> ~~~
 >> {: .bash}
 >> 
 >> ~~~
->> @SRR098026.249 HWUSI-EAS1599_1:2:1:2:1057 length=35
->> CNCTNTATGCGTACGGCAGTGANNNNNNNGGAGAT
->> +SRR098026.249 HWUSI-EAS1599_1:2:1:2:1057 length=35
->> A!@B!BBB@ABAB#########!!!!!!!######
+>> @SRR2584863.1553259 HWI-ST957:245:H73R4ADXX:2:2216:21048:100894/1
+>> CTGCAATACCACGCTGATCTTTCACATGATGTAAGAAAAGTGGGATCAGCAAACCGGGTGCTGCTGTGGCTAGTTGCAGCAAACCATGCAGTGAACCCGCCTGTGCTTCGCTATAGCCGTGACTGATGAGGATCGCCGGAAGCCAGCCAA
+>> +
+>> CCCFFFFFHHHHGJJJJJJJJJHGIJJJIJJJJIJJJJIIIIJJJJJJJJJJJJJIIJJJHHHHHFFFFFEEEEEDDDDDDDDDDDDDDDDDCDEDDBDBDDBDDDDDDDDDBDEEDDDD7@BDDDDDD>AA>?B?<@BDD@BDC?BDA?
 >> ~~~
 >> {: .output}
 >> 
->> The second half of this read is poor quality. Many of the positions are unknown
->> (`N`s) and the bases that we do have guesses for are of very poor
->> quality (`#`). However, the beginning of the read is fairly high 
->> quality. We will look at variations in position-based quality
+>> This read has more consistent quality at its end than the first 
+>> read that we looked at, but still has a range of quality scores, 
+>> most of them high. We will look at variations in position-based quality
 >> in just a moment.
 >> 
 > {: .solution}
 {: .challenge}
 
-> ## Quality Encodings Vary
->
-> Although we've used a particular quality encoding system to demonstrate interpretation of 
-> read quality, different sequencing machines use different encoding systems. This means that, 
-> depending on which sequencer you use to generate your data, a `#` may not be an indicator of 
-> a poor quality base call.
-
-> This mainly relates to older Solexa/Illumina data,
-> but it's essential that you know which sequencing platform was
-> used to generate your data, so that you can tell your quality control program which encoding
-> to use. If you choose the wrong encoding, you run the risk of throwing away good reads or 
-> (even worse) not throwing away bad reads!
-{: .callout}
 
 ## Assessing Quality using FastQC
 In real life, you won't be assessing the quality of your reads by visually inspecting your 
@@ -168,18 +177,19 @@ FASTQ files. Rather, you'll be using a software program to assess read quality a
 filter out poor quality reads. We'll first use a program called [FastQC](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/) to visualize the quality of our reads. 
 Later in our workflow, we'll use another program to filter out poor quality reads. 
 
-FastQC has a number of features which can give you a  quick impression of any problems your
+FastQC has a number of features which can give you a quick impression of any problems your
 data may have, so you can take these issues into consideration before moving forward with your
 analyses. Rather than looking at quality scores for each individual read, FastQC looks at
-quality collectively across all reads within a sample. The image below shows a FastQC-generated plot that indicates
+quality collectively across all reads within a sample. The image below shows one FastQC-generated plot that indicates
 a very high quality sample:
 
 ![good_quality](../img/good_quality1.8.png)
 
 The x-axis displays the base position in the read, and the y-axis shows quality scores. In this
-example, the sample contains reads that are 40 bp long. For each position, there is a 
-box-and-whisker plot showing the distribution of quality scores for all reads at that position.
-The horizontal red line indicates the median quality score and the yellow box shows the 2nd to
+example, the sample contains reads that are 40 bp long. This is much shorter than the reads we 
+are working with in our workflow. For each position, there is a box-and-whisker plot showing 
+the distribution of quality scores for all reads at that position. The horizontal red line 
+indicates the median quality score and the yellow box shows the 2nd to
 3rd quartile range. This means that 50% of reads have a quality score that falls within the
 range of the yellow box at that position. The whiskers show the range to the 1st and 4th 
 quartile.
@@ -196,16 +206,7 @@ Here, we see positions within the read in which the boxes span a much wider rang
 
 ## Running FastQC  
 
-We will be working with a set of sample data that is located in a hidden directory (`.dc_sampledata_lite`). First, we
-will move some of these hidden files to the `data` directory your created at [the end of our
-last lesson](http://www.datacarpentry.org/shell-genomics/06-organization/).  
-
-~~~
-$ mv ~/.dc_sampledata_lite/untrimmed_fastq/ ~/dc_workshop/data/
-~~~
-{: .bash}
-
-Navigate to your FASTQ dataset: 
+We will now assess the quality of the reads that we downloaded. First, make sure you're still in the `untrimmed_fastq` directory
 
 ~~~
 $ cd ~/dc_workshop/data/untrimmed_fastq/
@@ -214,7 +215,7 @@ $ cd ~/dc_workshop/data/untrimmed_fastq/
 
 > ## Exercise
 > 
-> How many FASTQ files are in this dataset? How big are the files?
+>  How big are the files?
 > (Hint: Look at the options for the `ls` command to see how to show
 > file sizes.)
 >
@@ -226,25 +227,24 @@ $ cd ~/dc_workshop/data/untrimmed_fastq/
 >> {: .bash}
 >> 
 >> ~~~
->> -rw-r--r-- 1 dcuser dcuser 840M Jul 30  2015 SRR097977.fastq
->> -rw-r--r-- 1 dcuser dcuser 3.4G Jul 30  2015 SRR098026.fastq
->> -rw-r--r-- 1 dcuser dcuser 875M Jul 30  2015 SRR098027.fastq
->> -rw-r--r-- 1 dcuser dcuser 3.4G Jul 30  2015 SRR098028.fastq
->> -rw-r--r-- 1 dcuser dcuser 4.0G Jul 30  2015 SRR098281.fastq
->> -rw-r--r-- 1 dcuser dcuser 3.9G Jul 30  2015 SRR098283.fastq
+>> -rw-rw-r-- 1 dcuser dcuser 545M Jul  6 20:27 SRR2584863_1.fastq
+>> -rw-rw-r-- 1 dcuser dcuser 183M Jul  6 20:29 SRR2584863_2.fastq.gz
+>> -rw-rw-r-- 1 dcuser dcuser 309M Jul  6 20:34 SRR2584866_1.fastq.gz
+>> -rw-rw-r-- 1 dcuser dcuser 296M Jul  6 20:37 SRR2584866_2.fastq.gz
+>> -rw-rw-r-- 1 dcuser dcuser 124M Jul  6 20:22 SRR2589044_1.fastq.gz
+>> -rw-rw-r-- 1 dcuser dcuser 128M Jul  6 20:24 SRR2589044_2.fastq.gz
 >> ~~~
 >> {: .output}
 >> 
->> There are six FASTQ files ranging from 840M (840MB) to 4.0G (4.0GB)
+>> There are six FASTQ files ranging from 124M (124MB) to 545M. 
 >> 
 > {: .solution}
 {: .challenge}
 
-To run the FastQC program, we need to tell our computer where the program is located 
-(in `~/FastQC`).  FastQC can accept multiple file names as input, so we can use the *.fastq wildcard to run FastQC on all of the FASTQ files in this directory.
+FastQC can accept multiple file names as input, and on both zipped and unzipped files, so we can use the \*.fastq* wildcard to run FastQC on all of the FASTQ files in this directory.
 
 ~~~
-$ ~/FastQC/fastqc *.fastq
+$ fastqc *.fastq*
 ~~~
 {: .bash}
 
@@ -252,17 +252,16 @@ You will see an automatically updating output message telling you the
 progress of the analysis. It will start like this: 
 
 ~~~
-Started analysis of SRR097977.fastq
-Approx 5% complete for SRR097977.fastq
-Approx 10% complete for SRR097977.fastq
-Approx 15% complete for SRR097977.fastq
-Approx 20% complete for SRR097977.fastq
-Approx 25% complete for SRR097977.fastq
-Approx 30% complete for SRR097977.fastq
-Approx 35% complete for SRR097977.fastq
-Approx 40% complete for SRR097977.fastq
-Approx 45% complete for SRR097977.fastq
-Approx 50% complete for SRR097977.fastq
+Started analysis of SRR2584863_1.fastq
+Approx 5% complete for SRR2584863_1.fastq
+Approx 10% complete for SRR2584863_1.fastq
+Approx 15% complete for SRR2584863_1.fastq
+Approx 20% complete for SRR2584863_1.fastq
+Approx 25% complete for SRR2584863_1.fastq
+Approx 30% complete for SRR2584863_1.fastq
+Approx 35% complete for SRR2584863_1.fastq
+Approx 40% complete for SRR2584863_1.fastq
+Approx 45% complete for SRR2584863_1.fastq
 ~~~
 {: .output}
 
@@ -271,17 +270,17 @@ six of our FASTQ files. When the analysis completes, your prompt
 will return. So your screen will look something like this:
 
 ~~~
-Approx 80% complete for SRR098283.fastq
-Approx 85% complete for SRR098283.fastq
-Approx 90% complete for SRR098283.fastq
-Approx 95% complete for SRR098283.fastq
-Analysis complete for SRR098283.fastq
-dcuser@ip-172-31-58-54:~/dc_workshop/data/untrimmed_fastq$
+Approx 80% complete for SRR2589044_2.fastq.gz
+Approx 85% complete for SRR2589044_2.fastq.gz
+Approx 90% complete for SRR2589044_2.fastq.gz
+Approx 95% complete for SRR2589044_2.fastq.gz
+Analysis complete for SRR2589044_2.fastq.gz
+(variants) dcuser@ip-172-31-49-42:~/dc_workshop/data/untrimmed_fastq$
 ~~~
 {: .output}
 
 The FastQC program has created several new files within our
-`/data/untrimmed_fastq/` directory. 
+`data/untrimmed_fastq/` directory. 
 
 ~~~
 $ ls
@@ -289,12 +288,12 @@ $ ls
 {: .bash}
 
 ~~~
-SRR097977.fastq        SRR098027.fastq	      SRR098281.fastq
-SRR097977_fastqc.html  SRR098027_fastqc.html  SRR098281_fastqc.html
-SRR097977_fastqc.zip   SRR098027_fastqc.zip   SRR098281_fastqc.zip
-SRR098026.fastq        SRR098028.fastq	      SRR098283.fastq
-SRR098026_fastqc.html  SRR098028_fastqc.html  SRR098283_fastqc.html
-SRR098026_fastqc.zip   SRR098028_fastqc.zip   SRR098283_fastqc.zip
+SRR2584863_1.fastq        SRR2584866_1_fastqc.html  SRR2589044_1_fastqc.html
+SRR2584863_1_fastqc.html  SRR2584866_1_fastqc.zip   SRR2589044_1_fastqc.zip
+SRR2584863_1_fastqc.zip   SRR2584866_1.fastq.gz     SRR2589044_1.fastq.gz
+SRR2584863_2_fastqc.html  SRR2584866_2_fastqc.html  SRR2589044_2_fastqc.html
+SRR2584863_2_fastqc.zip   SRR2584866_2_fastqc.zip   SRR2589044_2_fastqc.zip
+SRR2584863_2.fastq.gz     SRR2584866_2.fastq.gz     SRR2589044_2.fastq.gz
 ~~~
 {: .output}
 
@@ -323,13 +322,13 @@ $ cd ~/dc_workshop/results/fastqc_untrimmed_reads/
 ~~~
 {: .bash}
 
-## Viewing HTML files
+## Viewing the FastQC results
 
 If we were working on our local computers, we'd be able to display each of these 
 HTML files as a webpage: 
  
 ~~~
-$ open SRR097977_fastqc.html
+$ open SRR2584863_1_fastqc.html
 ~~~
 {: .bash}
 
@@ -346,19 +345,9 @@ open the file. We want to look at the webpage summary reports, so
 let's transfer them to our local computers (i.e. your laptop).
 
 To transfer a file from a remote server to our own machines, we will
-use a variant of the `cp` command called `scp`. The `s` stands for
-"secure" - this is a secure version of copying. 
+use `scp`, which we learned yesterday in the Shell Genomics lesson. 
 
-For the `cp` command, the syntax was:
-
-~~~
-$ cp my_file new_location
-~~~
-{: .bash}
-
-The syntax for `scp` is the same, but now `my_file` and
-`new_location` are on separate computers, so we need to give an 
-absolute path, including the name of our remote computer. First we
+First we
 will make a new directory on our computer to store the HTML files
 we're transfering. Let's put it on our desktop for now. Open a new
 tab in your terminal program (you can use the pull down menu at the
@@ -376,7 +365,7 @@ $ scp dcuser@ec2-34-238-162-94.compute-1.amazonaws.com:~/dc_workshop/results/fas
 ~~~
 {: .bash}
 
-This looks really complicated, so let's break it down. The first part
+As a reminder, the first part
 of the command `dcuser@ec2-34-238-162-94.compute-1.amazonaws.com` is
 the address for your remote computer. Make sure you replace everything
 after `dcuser@` with your instance number (the one you used to log in). 
@@ -393,12 +382,12 @@ directory we just created `~/Desktop/fastqc_html`.
 You should see a status output like this:
 
 ~~~
-SRR097977_fastqc.html                                    100%  318KB 317.8KB/s   00:01    
-SRR098026_fastqc.html                                    100%  330KB 329.8KB/s   00:00    
-SRR098027_fastqc.html                                    100%  369KB 369.5KB/s   00:00    
-SRR098028_fastqc.html                                    100%  323KB 323.4KB/s   00:01    
-SRR098281_fastqc.html                                    100%  329KB 329.1KB/s   00:00    
-SRR098283_fastqc.html                                    100%  324KB 323.5KB/s   00:00 
+SRR2584863_1_fastqc.html                      100%  249KB 152.3KB/s   00:01    
+SRR2584863_2_fastqc.html                      100%  254KB 219.8KB/s   00:01    
+SRR2584866_1_fastqc.html                      100%  254KB 271.8KB/s   00:00    
+SRR2584866_2_fastqc.html                      100%  251KB 252.8KB/s   00:00    
+SRR2589044_1_fastqc.html                      100%  249KB 370.1KB/s   00:00    
+SRR2589044_2_fastqc.html                      100%  251KB 592.2KB/s   00:00  
 ~~~
 {: .output}
 
@@ -421,12 +410,25 @@ tabs in a single window or six separate browser windows.
 > worst?
 > 
 >> ## Solution
->> `SRR097977` and `SRR098027` are the best. The other four 
->> samples are all pretty bad.
+>> All of the reads contain usable data, but the quality decreases toward
+>> the end of the reads.
 > {: .solution}
 {: .challenge}
 
-## Unzipping Compressed Files
+## Decoding the other FastQC outputs
+We've now looked at quite a few "Per base sequence quality" FastQC graphs, but there are nine other graphs that we haven't talked about! Below we have provided a brief overview of interpretations for each of these plots. It's important to keep in mind 
+
++ Per tile sequence quality: the machines that perform sequencing are divided into tiles. This plot displays patterns in base quality along these tiles. Consistently low scores are often found around the edges, but hot spots can also occur in the middle if an air bubble was introduced at some point during the run. 
++ Per sequence quality scores: a density plot of quality for all reads at all positions. This plot shows what quality scores are most common. 
++ Per base sequence content: plots the proportion of each base position over all of the reads. Typically, we expect to see each base roughly 25% of the time at each position, but this often fails at the beginning or end of the read due to quality or adapter content.
++ Per sequence GC content: a density plot of average GC content in each of the reads.  
++ Per base N content: the percent of times that 'N' occurs at a position in all reads. If there is an increase at a particular position, this might indicate that something went wrong during sequencing.  
++ Sequence Length Distribution: the distribution of sequence lengths of all reads in the file. If the data is raw, there is often on sharp peak, however if the reads have been trimmed, there may be a distribution of shorter lengths. 
++ Sequence Duplication Levels: A distribution of duplicated sequences. In sequencing, we expect most reads to only occur once. If some sequences are occurring more than once, it might indicate enrichment bias (e.g. from PCR). If the samples are high coverage (or RNA-seq or amplicon), this might not be true.  
++ Overrepresented sequences: A list of sequences that occur more frequently than would be expected by chance. 
++ Adapter Content: a graph indicating where adapater sequences occur in the reads.
+
+## Working with the FastQC text output
 
 Now that we've looked at our HTML reports to get a feel for the data,
 let's look more closely at the other output files. Go back to the tab
@@ -441,10 +443,10 @@ $ ls
 {: .bash}
 
 ~~~
-SRR097977_fastqc.html  SRR098027_fastqc.html  SRR098281_fastqc.html
-SRR097977_fastqc.zip   SRR098027_fastqc.zip   SRR098281_fastqc.zip
-SRR098026_fastqc.html  SRR098028_fastqc.html  SRR098283_fastqc.html
-SRR098026_fastqc.zip   SRR098028_fastqc.zip   SRR098283_fastqc.zip
+SRR2584863_1_fastqc.html  SRR2584866_1_fastqc.html  SRR2589044_1_fastqc.html
+SRR2584863_1_fastqc.zip   SRR2584866_1_fastqc.zip   SRR2589044_1_fastqc.zip
+SRR2584863_2_fastqc.html  SRR2584866_2_fastqc.html  SRR2589044_2_fastqc.html
+SRR2584863_2_fastqc.zip   SRR2584866_2_fastqc.zip   SRR2589044_2_fastqc.zip
 ~~~
 {: .output}
 
@@ -460,12 +462,12 @@ $ unzip *.zip
 {: .bash}
 
 ~~~
-Archive:  SRR097977_fastqc.zip
-caution: filename not matched:  SRR098026_fastqc.zip
-caution: filename not matched:  SRR098027_fastqc.zip
-caution: filename not matched:  SRR098028_fastqc.zip
-caution: filename not matched:  SRR098281_fastqc.zip
-caution: filename not matched:  SRR098283_fastqc.zip
+Archive:  SRR2584863_1_fastqc.zip
+caution: filename not matched:  SRR2584863_2_fastqc.zip
+caution: filename not matched:  SRR2584866_1_fastqc.zip
+caution: filename not matched:  SRR2584866_2_fastqc.zip
+caution: filename not matched:  SRR2589044_1_fastqc.zip
+caution: filename not matched:  SRR2589044_2_fastqc.zip
 ~~~
 {: .output}
 
@@ -475,7 +477,7 @@ expects to get only one zip file as input. We could go through and
 unzip each file one at a time, but this is very time consuming and 
 error-prone. Someday you may have 500 files to unzip!
 
-A more efficient way is to use a `for` loop to iterate through all of
+A more efficient way is to use a `for` loop like we learned in the Shell Genomics lesson to iterate through all of
 our `.zip` files. Let's see what that looks like and then we'll 
 discuss what we're doing with each line of our loop.
 
@@ -487,116 +489,41 @@ $ for filename in *.zip
 ~~~
 {: .bash}
 
-When the shell sees the keyword `for`,
-it knows to repeat a command (or group of commands) once for each item in a list.
-Each time the loop runs (called an iteration), an item in the list is assigned in sequence to
-the **variable**, and the commands inside the loop are executed, before moving on to 
-the next item in the list.
-
-Inside the loop,
-we call for the variable's value by putting `$` in front of it.
-The `$` tells the shell interpreter to treat
-the **variable** as a variable name and substitute its value in its place,
-rather than treat it as text or an external command. 
-
-In this example, the list is six filenames (one filename for each of our `.zip` files).
+In this example, the input is six filenames (one filename for each of our `.zip` files).
 Each time the loop iterates, it will assign a file name to the variable `filename`
 and run the `unzip` command.
 The first time through the loop,
-`$filename` is `SRR097977_fastqc.zip`. 
-The interpreter runs the command `unzip` on `SRR097977_fastqc.zip`.
+`$filename` is `SRR2584863_1_fastqc.zip`. 
+The interpreter runs the command `unzip` on `SRR2584863_1_fastqc.zip`.
 For the second iteration, `$filename` becomes 
-`SRR098026_fastqc.zip`. This time, the shell runs `unzip` on `SRR098026_fastqc.zip`.
+`SRR2584863_2_fastqc.zip`. This time, the shell runs `unzip` on `SRR2584863_2_fastqc.zip`.
 It then repeats this process for the four other `.zip` files in our directory.
 
-> ## Follow the Prompt
->
-> The shell prompt changes from `$` to `>` and back again as we were
-> typing in our loop. The second prompt, `>`, is different to remind
-> us that we haven't finished typing a complete command yet. A semicolon, `;`,
-> can be used to separate two commands written on a single line.
-{: .callout}
-
-> ## Same Symbols, Different Meanings
->
-> Here we see `>` being used a shell prompt, whereas `>` is also
-> used to redirect output.
-> Similarly, `$` is used as a shell prompt, but, as we saw earlier,
-> it is also used to ask the shell to get the value of a variable.
->
-> If the *shell* prints `>` or `$` then it expects you to type something,
-> and the symbol is a prompt.
->
-> If *you* type `>` or `$` yourself, it is an instruction from you that
-> the shell to redirect output or get the value of a variable.
-{: .callout}
-
-We have called the variable in this loop `filename`
-in order to make its purpose clearer to human readers.
-The shell itself doesn't care what the variable is called;
-if we wrote this loop as:
-
-~~~
-$ for x in *.zip
-> do
-> unzip $x
-> done
-~~~
-{: .bash}
-
-or:
-
-~~~
-$ for temperature in *.zip
-> do
-> unzip $temperature
-> done
-~~~
-{: .bash}
-
-it would work exactly the same way.
-*Don't do this.*
-Programs are only useful if people can understand them,
-so meaningless names (like `x`) or misleading names (like `temperature`)
-increase the odds that the program won't do what its readers think it does.
-
-> ## Multipart commands
-> The `for` loop is interpreted as a multipart command.  If you press the up arrow on your keyboard to recall the command, it will be shown like so:
->
-> ~~~   
-> $ for zip in *.zip; do echo File $zip; unzip $zip; done
-> ~~~
-> {: .bash}
-> 
-> When you check your history later, it will help your remember what you did!
->
-{: .callout}
 
 When we run our `for` loop, you will see output that starts like this:
 
 ~~~
-Archive:  SRR097977_fastqc.zip
-creating: SRR097977_fastqc/
-creating: SRR097977_fastqc/Icons/
-creating: SRR097977_fastqc/Images/
-inflating: SRR097977_fastqc/Icons/fastqc_icon.png  
-inflating: SRR097977_fastqc/Icons/warning.png  
-inflating: SRR097977_fastqc/Icons/error.png  
-inflating: SRR097977_fastqc/Icons/tick.png  
-inflating: SRR097977_fastqc/summary.txt  
-inflating: SRR097977_fastqc/Images/per_base_quality.png  
-inflating: SRR097977_fastqc/Images/per_tile_quality.png  
-inflating: SRR097977_fastqc/Images/per_sequence_quality.png  
-inflating: SRR097977_fastqc/Images/per_base_sequence_content.png  
-inflating: SRR097977_fastqc/Images/per_sequence_gc_content.png  
-inflating: SRR097977_fastqc/Images/per_base_n_content.png  
-inflating: SRR097977_fastqc/Images/sequence_length_distribution.png  
-inflating: SRR097977_fastqc/Images/duplication_levels.png  
-inflating: SRR097977_fastqc/Images/adapter_content.png  
-inflating: SRR097977_fastqc/Images/kmer_profiles.png  
-inflating: SRR097977_fastqc/fastqc_report.html  
-inflating: SRR097977_fastqc/fastqc_data.txt  
-inflating: SRR097977_fastqc/fastqc.fo  
+Archive:  SRR2589044_2_fastqc.zip
+   creating: SRR2589044_2_fastqc/
+   creating: SRR2589044_2_fastqc/Icons/
+   creating: SRR2589044_2_fastqc/Images/
+  inflating: SRR2589044_2_fastqc/Icons/fastqc_icon.png  
+  inflating: SRR2589044_2_fastqc/Icons/warning.png  
+  inflating: SRR2589044_2_fastqc/Icons/error.png  
+  inflating: SRR2589044_2_fastqc/Icons/tick.png  
+  inflating: SRR2589044_2_fastqc/summary.txt  
+  inflating: SRR2589044_2_fastqc/Images/per_base_quality.png  
+  inflating: SRR2589044_2_fastqc/Images/per_tile_quality.png  
+  inflating: SRR2589044_2_fastqc/Images/per_sequence_quality.png  
+  inflating: SRR2589044_2_fastqc/Images/per_base_sequence_content.png  
+  inflating: SRR2589044_2_fastqc/Images/per_sequence_gc_content.png  
+  inflating: SRR2589044_2_fastqc/Images/per_base_n_content.png  
+  inflating: SRR2589044_2_fastqc/Images/sequence_length_distribution.png  
+  inflating: SRR2589044_2_fastqc/Images/duplication_levels.png  
+  inflating: SRR2589044_2_fastqc/Images/adapter_content.png  
+  inflating: SRR2589044_2_fastqc/fastqc_report.html  
+  inflating: SRR2589044_2_fastqc/fastqc_data.txt  
+  inflating: SRR2589044_2_fastqc/fastqc.fo  
 ~~~
 {: .output}
 
@@ -606,17 +533,15 @@ store all of the different output that is produced by FastQC. There
 are a lot of files here. The one we're going to focus on is the 
 `summary.txt` file. 
 
-## Understanding FastQC Output
-
 If you list the files in our directory now you will see: 
 
 ~~~
-SRR097977_fastqc       SRR098027_fastqc       SRR098281_fastqc
-SRR097977_fastqc.html  SRR098027_fastqc.html  SRR098281_fastqc.html
-SRR097977_fastqc.zip   SRR098027_fastqc.zip   SRR098281_fastqc.zip
-SRR098026_fastqc       SRR098028_fastqc       SRR098283_fastqc
-SRR098026_fastqc.html  SRR098028_fastqc.html  SRR098283_fastqc.html
-SRR098026_fastqc.zip   SRR098028_fastqc.zip   SRR098283_fastqc.zip
+SRR2584863_1_fastqc       SRR2584866_1_fastqc       SRR2589044_1_fastqc
+SRR2584863_1_fastqc.html  SRR2584866_1_fastqc.html  SRR2589044_1_fastqc.html
+SRR2584863_1_fastqc.zip   SRR2584866_1_fastqc.zip   SRR2589044_1_fastqc.zip
+SRR2584863_2_fastqc       SRR2584866_2_fastqc       SRR2589044_2_fastqc
+SRR2584863_2_fastqc.html  SRR2584866_2_fastqc.html  SRR2589044_2_fastqc.html
+SRR2584863_2_fastqc.zip   SRR2584866_2_fastqc.zip   SRR2589044_2_fastqc.zip
 ~~~
 {:. output}
 
@@ -630,19 +555,19 @@ $ ls -F
 {: .bash}
 
 ~~~
-SRR097977_fastqc/      SRR098027_fastqc/      SRR098281_fastqc/
-SRR097977_fastqc.html  SRR098027_fastqc.html  SRR098281_fastqc.html
-SRR097977_fastqc.zip   SRR098027_fastqc.zip   SRR098281_fastqc.zip
-SRR098026_fastqc/      SRR098028_fastqc/      SRR098283_fastqc/
-SRR098026_fastqc.html  SRR098028_fastqc.html  SRR098283_fastqc.html
-SRR098026_fastqc.zip   SRR098028_fastqc.zip   SRR098283_fastqc.zip
+SRR2584863_1_fastqc/      SRR2584866_1_fastqc/      SRR2589044_1_fastqc/
+SRR2584863_1_fastqc.html  SRR2584866_1_fastqc.html  SRR2589044_1_fastqc.html
+SRR2584863_1_fastqc.zip   SRR2584866_1_fastqc.zip   SRR2589044_1_fastqc.zip
+SRR2584863_2_fastqc/      SRR2584866_2_fastqc/      SRR2589044_2_fastqc/
+SRR2584863_2_fastqc.html  SRR2584866_2_fastqc.html  SRR2589044_2_fastqc.html
+SRR2584863_2_fastqc.zip   SRR2584866_2_fastqc.zip   SRR2589044_2_fastqc.zip
 ~~~
 {: .output}
 
 Let's see what files are present within one of these output directories.
 
 ~~~
-$ ls -F SRR097977_fastqc/
+$ ls -F SRR2584863_1_fastqc/
 ~~~
 {: .bash}
 
@@ -654,23 +579,22 @@ fastqc_data.txt  fastqc.fo  fastqc_report.html	Icons/	Images/  summary.txt
 Use `less` to preview the `summary.txt` file for this sample. 
 
 ~~~
-$ less SRR097977_fastqc/summary.txt
+$ less SRR2584863_1_fastqc/summary.txt
 ~~~
 {: .bash}
 
 ~~~
-PASS    Basic Statistics        SRR097977.fastq
-WARN    Per base sequence quality       SRR097977.fastq
-FAIL    Per tile sequence quality       SRR097977.fastq
-PASS    Per sequence quality scores     SRR097977.fastq
-PASS    Per base sequence content       SRR097977.fastq
-PASS    Per sequence GC content SRR097977.fastq
-PASS    Per base N content      SRR097977.fastq
-PASS    Sequence Length Distribution    SRR097977.fastq
-PASS    Sequence Duplication Levels     SRR097977.fastq
-PASS    Overrepresented sequences       SRR097977.fastq
-PASS    Adapter Content SRR097977.fastq
-WARN    Kmer Content    SRR097977.fastq
+PASS    Basic Statistics        SRR2584863_1.fastq
+PASS    Per base sequence quality       SRR2584863_1.fastq
+PASS    Per tile sequence quality       SRR2584863_1.fastq
+PASS    Per sequence quality scores     SRR2584863_1.fastq
+WARN    Per base sequence content       SRR2584863_1.fastq
+WARN    Per sequence GC content SRR2584863_1.fastq
+PASS    Per base N content      SRR2584863_1.fastq
+PASS    Sequence Length Distribution    SRR2584863_1.fastq
+PASS    Sequence Duplication Levels     SRR2584863_1.fastq
+PASS    Overrepresented sequences       SRR2584863_1.fastq
+WARN    Adapter Content SRR2584863_1.fastq
 ~~~
 {: .output}
 
@@ -705,63 +629,52 @@ $ cat */summary.txt > ~/dc_workshop/docs/fastqc_summaries.txt
 >> {: .bash}
 >> 
 >> ~~~
->> FAIL	Per tile sequence quality	SRR097977.fastq
->> FAIL	Per tile sequence quality	SRR098026.fastq
->> FAIL	Overrepresented sequences	SRR098026.fastq
->> FAIL	Kmer Content	SRR098026.fastq
->> FAIL	Per base sequence quality	SRR098027.fastq
->> FAIL	Per tile sequence quality	SRR098027.fastq
->> FAIL	Kmer Content	SRR098027.fastq
->> FAIL	Per tile sequence quality	SRR098028.fastq
->> FAIL	Overrepresented sequences	SRR098028.fastq
->> FAIL	Kmer Content	SRR098028.fastq
->> FAIL	Overrepresented sequences	SRR098281.fastq
->> FAIL	Kmer Content	SRR098281.fastq
->> FAIL	Overrepresented sequences	SRR098283.fastq
->> FAIL	Kmer Content	SRR098283.fastq
+>> FAIL    Per base sequence quality       SRR2584863_2.fastq.gz
+>> FAIL    Per tile sequence quality       SRR2584863_2.fastq.gz
+>> FAIL    Per base sequence content       SRR2584863_2.fastq.gz
+>> FAIL    Per base sequence quality       SRR2584866_1.fastq.gz
+>> FAIL    Per base sequence content       SRR2584866_1.fastq.gz
+>> FAIL    Adapter Content SRR2584866_1.fastq.gz
+>> FAIL    Adapter Content SRR2584866_2.fastq.gz
+>> FAIL    Adapter Content SRR2589044_1.fastq.gz
+>> FAIL    Per base sequence quality       SRR2589044_2.fastq.gz
+>> FAIL    Per tile sequence quality       SRR2589044_2.fastq.gz
+>> FAIL    Per base sequence content       SRR2589044_2.fastq.gz
+>> FAIL    Adapter Content SRR2589044_2.fastq.gz
 >> ~~~
->> {: .output}
+>> {: .output
 >> 
->> If we want to see all the files that failed at least one test, we
->> can use a combination of `grep`, `cut`, `sort` and `uniq`. 
->> 
->> ~~~
->> $ grep FAIL fastqc_summaries.txt | cut -f 3 | sort | uniq
->> ~~~
->> {: .bash}
->>
->> ~~~
->> SRR097977.fastq
->> SRR098026.fastq
->> SRR098027.fastq
->> SRR098028.fastq
->> SRR098281.fastq
->> SRR098283.fastq
->> ~~~
->> {: .output}
->> 
->> All of our samples failed at least one test. If we want to see a table showing which tests failed, we can 
->> use the same command we used above, but this time extract the 
->> second field with `cut` (instead of the third) and add the `-c` 
->> option to `uniq` to count the number of times each unique value
->> appears.
->>
->> ~~~
->> $ grep FAIL fastqc_summaries.txt | cut -f 2 | sort | uniq -c
->> ~~~
->> {: .bash}
->> 
->> ~~~
->> 5 Kmer Content
->> 4 Overrepresented sequences
->> 1 Per base sequence quality
->> 4 Per tile sequence quality
->> ~~~
->> {: .output}
 > {: .solution}
 {: .challenge}
 
 
+# Other notes  -- Optional 
+
+> ## Quality Encodings Vary
+>
+> Although we've used a particular quality encoding system to demonstrate interpretation of 
+> read quality, different sequencing machines use different encoding systems. This means that, 
+> depending on which sequencer you use to generate your data, a `#` may not be an indicator of 
+> a poor quality base call.
+
+> This mainly relates to older Solexa/Illumina data,
+> but it's essential that you know which sequencing platform was
+> used to generate your data, so that you can tell your quality control program which encoding
+> to use. If you choose the wrong encoding, you run the risk of throwing away good reads or 
+> (even worse) not throwing away bad reads!
+{: .callout}
 
 
-
+> ## Same Symbols, Different Meanings
+>
+> Here we see `>` being used a shell prompt, whereas `>` is also
+> used to redirect output.
+> Similarly, `$` is used as a shell prompt, but, as we saw earlier,
+> it is also used to ask the shell to get the value of a variable.
+>
+> If the *shell* prints `>` or `$` then it expects you to type something,
+> and the symbol is a prompt.
+>
+> If *you* type `>` or `$` yourself, it is an instruction from you that
+> the shell to redirect output or get the value of a variable.
+{: .callout}

--- a/_episodes/01-trimming.md
+++ b/_episodes/01-trimming.md
@@ -233,7 +233,7 @@ $ for infile in *_1.fastq.gz
 
 Go ahead and run the for loop. It should take a few minutes for
 Trimmomatic to run for each of our six input files. Once it's done
-running, take a look at your directory contents.
+running, take a look at your directory contents. You'll notice that even though we ran Trimmomatic on file `SRR2589044` before running the for loop, there is only one set of files for it. Because of we matched the ending `_1.fastq.gz`, we re-ran Trimmomatic on this file, overwriting our first results. That's ok, but it's good to be aware that it happened.
 
 ~~~
 $ ls

--- a/_episodes/01-trimming.md
+++ b/_episodes/01-trimming.md
@@ -81,12 +81,12 @@ analysis. It is important to understand the steps you are using to
 clean your data. For more information about the Trimmomatic arguments
 and options, see [the Trimmomatic manual](http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/TrimmomaticManual_V0.32.pdf).
 
-However, a complete command for Trimmomatic will look something like this:
+However, a complete command for Trimmomatic will look something like the command below. This command is an example and will not work as we do not have the files it refers to:
 
 ~~~
 $ trimmomatic PE -threads 4 SRR_1056_1.fastq SRR_1056_2.fastq  \
               SRR_1056_1.trimmed.fastq SRR_1056_1un.trimmed.fastq \
-              SRR_1056_2.trimmed.fastq SRR_1056_2un.trimmed.fastq
+              SRR_1056_2.trimmed.fastq SRR_1056_2un.trimmed.fastq \
               ILLUMINACLIP:SRR_adapters.fa SLIDINGWINDOW:4:20
 ~~~
 {: .bash}
@@ -120,7 +120,7 @@ We saw using FastQC that Nextera adapters were present in our samples.
 The adapter sequences came with the installation of trimmomatic, so we will first copy these sequences into our current directory.
 
 ~~~
-$ cp ~/miniconda3/share/trimmomatic-0.38-0/adapters/NexteraPE-PE.fa .
+$ cp ~/miniconda3/pkgs/trimmomatic-0.38-0/share/trimmomatic-0.38-0/adapters/NexteraPE-PE.fa .
 ~~~
 {: .bash}
 
@@ -259,12 +259,13 @@ SRR2584863_2un.trim.fastq.gz  SRR2589044_1.fastq.gz
 >
 >> ## Solution
 >> ~~~
->> $ ls ~/miniconda3/share/trimmomatic-0.38-0/adapters
+>> $ ls ~/miniconda3/pkgs/trimmomatic-0.38-0/share/trimmomatic-0.38-0/adapters/
 >> ~~~
 >> {: .bash}
 >>
 >> ~~~
->> TruSeq2-PE.fa  TruSeq2-SE.fa  TruSeq3-PE-2.fa  TruSeq3-PE.fa  TruSeq3-SE.fa
+>> NexteraPE-PE.fa  TruSeq2-SE.fa    TruSeq3-PE.fa
+>> TruSeq2-PE.fa    TruSeq3-PE-2.fa  TruSeq3-SE.fa
 >> ~~~
 >> {: .output}
 >>

--- a/_episodes/02-variant_calling.md
+++ b/_episodes/02-variant_calling.md
@@ -37,7 +37,9 @@ First we download the reference genome for *E. coli* REL606. Although we could c
 
 ~~~
 $ cd ~/dc_workshop
-$ curl -L -O data/ref_genome/ecoli_rel606.fasta ftp://dummy.fa
+$ mkdir data/ref_genome
+$ curl -L -o data/ref_genome/ecoli_rel606.fasta.gz ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/017/985/GCA_000017985.1_ASM1798v1/GCA_000017985.1_ASM1798v1_genomic.fna.gz
+$ gunzip data/ref_genome/ecoli_rel606.fasta.gz
 ~~~
 {: .bash}
 
@@ -45,7 +47,7 @@ We will also download a set of trimmed FASTQ files to work with. These are small
 and will enable us to run our variant calling workflow quite quickly. 
 
 ~~~
-$ $ curl -L -O data/trimmed-fastq-small/ ftp://dummy.fa 
+$ curl -L -O data/trimmed-fastq-small/ ftp://dummy.fa 
 ~~~
 {: .bash}
 
@@ -71,15 +73,15 @@ $ bwa index data/ref_genome/ecoli_rel606.fasta
 While the index is created, you will see output something like this:
 
 ~~~
-[bwa_index] Pack FASTA... 0.04 sec
+[bwa_index] Pack FASTA... 0.09 sec
 [bwa_index] Construct BWT for the packed sequence...
 [bwa_index] 1.05 seconds elapse.
 [bwa_index] Update BWT... 0.03 sec
-[bwa_index] Pack forward-only FASTA... 0.02 sec
-[bwa_index] Construct SA from BWT and Occ... 0.54 sec
-[main] Version: 0.7.5a-r405
+[bwa_index] Pack forward-only FASTA... 0.07 sec
+[bwa_index] Construct SA from BWT and Occ... 0.55 sec
+[main] Version: 0.7.17-r1188
 [main] CMD: bwa index data/ref_genome/ecoli_rel606.fasta
-[main] Real time: 1.736 sec; CPU: 1.688 sec
+[main] Real time: 2.066 sec; CPU: 1.791 sec
 ~~~
 {: .output}
 
@@ -103,14 +105,23 @@ samples in our dataset (`SRRXXXXXXX.fastq`). Later, we'll be
 iterating this whole process on all of our sample files.
 
 ~~~
-$ bwa mem data/ref_genome/ecoli_rel606.fasta data/trimmed_fastq_small/SRR097977.fastq_trim.fastq > results/sai/SRR097977.aligned.sam
+$ bwa mem data/ref_genome/ecoli_rel606.fasta data/trimmed_fastq_small/SRR097977.fastq_trim.fastq > results/sam/SRR097977.aligned.sam
 ~~~
 {: .bash}
 
 You will see output that starts like this: 
 
 ~~~
-PASTE OUTPUT
+[M::bwa_idx_load_from_disk] read 0 ALT contigs
+[M::process] read 77306 sequences (10000019 bp)...
+[M::process] read 74782 sequences (10000171 bp)...
+[M::mem_pestat] # candidate unique pairs for (FF, FR, RF, RR): (190, 36660, 10, 167)
+[M::mem_pestat] analyzing insert size distribution for orientation FF...
+[M::mem_pestat] (25, 50, 75) percentile: (388, 713, 1646)
+[M::mem_pestat] low and high boundaries for computing mean and std.dev: (1, 4162)
+[M::mem_pestat] mean and std.dev: (961.98, 966.38)
+[M::mem_pestat] low and high boundaries for proper pairs: (1, 5420)
+[M::mem_pestat] analyzing insert size distribution for orientation FR...
 ~~~
 {: .output}
 
@@ -179,7 +190,7 @@ variants.
 Do the first pass on variant calling by counting read coverage with [bcftools](https://samtools.github.io/bcftools/bcftools.html). We will use the command `mpileup`. The flag `-g` tells samtools to generate a bcf format output file, `-o` specifies where to write the output file, and `-f` flags the path to the reference genome:
 
 ~~~
-$ bcftools mpileup -g -o results/bcf/SRR097977_raw.bcf \
+$ bcftools mpileup -O b -o results/bcf/SRR097977_raw.bcf \
 -f data/ref_genome/ecoli_rel606.fasta results/bam/SRR097977.aligned.sorted.bam 
 ~~~
 {: .bash}

--- a/_episodes/02-variant_calling.md
+++ b/_episodes/02-variant_calling.md
@@ -93,6 +93,8 @@ The alignment process consists of choosing an appropriate reference genome to ma
 aligner. We will use the BWA-MEM algorithm, which is the latest and is generally recommended for high-quality queries as it 
 is faster and more accurate.
 
+An example of what a `bwa` command looks like is below. This command will not run, as we do not have the files `ref_genome.fa`, `input_file_R1.fastq`, or `input_file_R2.fastq`.
+
 ~~~
 $ bwa mem ref_genome.fasta input_file_R1.fastq input_file_R2.fastq > output.sam
 ~~~
@@ -178,6 +180,31 @@ Our files are pretty small, so we won't see this output. If you run the workflow
 
 SAM/BAM files can be sorted in multiple ways, e.g. by location of alignment on the chromosome, by read name, etc. It is important to be aware that different alignment tools will output differently sorted SAM/BAM, and different downstream tools require differently sorted alignment files as input.
 
+You can use samtools to learn more about this bam file as well.
+
+~~~
+samtools flagstat results/bam/SRR2584863.aligned.sorted.bam
+~~~
+{: .bash}
+
+This will give you the following statistics about your sorted bam file:
+
+~~~
+352019 + 0 in total (QC-passed reads + QC-failed reads)
+0 + 0 secondary
+2019 + 0 supplementary
+0 + 0 duplicates
+351867 + 0 mapped (99.96% : N/A)
+350000 + 0 paired in sequencing
+175000 + 0 read1
+175000 + 0 read2
+343112 + 0 properly paired (98.03% : N/A)
+349706 + 0 with itself and mate mapped
+142 + 0 singletons (0.04% : N/A)
+0 + 0 with mate mapped to a different chr
+0 + 0 with mate mapped to a different chr (mapQ>=5)
+~~~
+{: .output}
 ## Variant calling
 
 A variant call is a conclusion that there is a nucleotide difference vs. some reference at a given position in an individual genome
@@ -219,7 +246,7 @@ $ bcftools call --ploidy 1 -m -v -o results/bcf/SRR2584863_variants.vcf results/
 Filter the SNPs for the final output in VCF format, using `vcfutils.pl`:
 
 ~~~
-$ vcfutils.pl varFilter results/bcf/SRR2584863_variants.bcf  > results/vcf/SRR2584863_final_variants.vcf
+$ vcfutils.pl varFilter results/bcf/SRR2584863_variants.vcf  > results/vcf/SRR2584863_final_variants.vcf
 ~~~
 {: .bash}
 
@@ -327,16 +354,16 @@ to learn more about VCF file format.
 >> ## Solution
 >> 
 >> ~~~
->> $ grep -v "##" results/vcf/SRR2584863_final_variants.vcf | wc -l
+>> $ grep -v "#" results/vcf/SRR2584863_final_variants.vcf | wc -l
 >> ~~~
 >> {: .bash}
 >> 
 >> ~~~ 
->> 26
+>> 25
 >> ~~~
 >> {: .output}
 >>
->> There are 26 variants in this file.
+>> There are 25 variants in this file.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
This PR integrates the new dataset, and updates the commands to new versions installed with miniconda3.

I have run everything on a dcuser instance and it all works, except the samtools tview step. However, the vcf file looks great (26 variants distributed throughout the genome), so I will debug this bit later.

I have edited everything up until Automation, but want these changes cleared before I automate them. 

I set up my instance like this:
```
wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
bash Miniconda3-latest-Linux-x86_64.sh
conda config --add channels bioconda
conda config --add channels conda-forge
conda config --add channels defaults

# These two steps are optional, but should be run while using the instances that 
# were made for DC Genomics to avoid software installation conflicts. 
# These two steps create and activate a conda environment.
conda create -n variants python==3.6
source activate variants

conda install -c bioconda bwa=0.7.17 samtools=1.3.1 bcftools=1.8 trimmomatic=0.38 fastqc=0.11.7
```

And subsampled the trimmed files like this:
```
for infile in data/trimmed_fastq/*_1.trim.fastq.gz
do
    base=$(basename ${infile} _1.trim.fastq.gz)
    gunzip -c ${infile} | head -n 700000 > sub/${base}_1.trim.sub.fastq
    gunzip -c data/trimmed_fastq/${base}_2.trim.fastq.gz | head -n 700000 > sub/${base}_2.trim.sub.fastq
done
```

@fpsom @crazyhottommy ready for review!