### PR TITLE
update ls flag to sort by size

### DIFF
--- a/_episodes/01-trimming.md
+++ b/_episodes/01-trimming.md
@@ -187,10 +187,11 @@ SRR2589044_1.trim.fastq.gz  SRR2589044_2.fastq.gz         SRR2589044_2un.trim.fa
 {: .output}
 
 The output file is also a FASTQ file. It should be smaller than our
-input file because we've removed reads. We can confirm this:
+input file because we've removed reads. We can confirm this 
+by running the `ls` command with the `-S` flag to sort by size.
 
 ~~~
-$ ls SRR2589044* -l -h
+$ ls SRR2589044* -l -S
 ~~~
 {: .bash}
 


### PR DESCRIPTION
This is not necessary, but since we are talking about size, I think it would be nice to use the `ls -S` to sort by size. I chose to omit the `h` flag because the size difference is more noticeable in non-human readable form.

```
-rw-rw-r-- 1 dcuser dcuser 128M Oct  9 16:23 SRR2589044_2.fastq.gz
-rw-rw-r-- 1 dcuser dcuser 124M Oct  9 16:20 SRR2589044_1.fastq.gz
-rw-rw-r-- 1 dcuser dcuser  94M Oct  9 18:40 SRR2589044_1.trim.fastq.gz
-rw-rw-r-- 1 dcuser dcuser  91M Oct  9 18:40 SRR2589044_2.trim.fastq.gz
-rw-rw-r-- 1 dcuser dcuser  18M Oct  9 18:40 SRR2589044_1un.trim.fastq.gz
-rw-rw-r-- 1 dcuser dcuser 271K Oct  9 18:40 SRR2589044_2un.trim.fastq.gz
```
versus

```
-rw-rw-r-- 1 dcuser dcuser 134214678 Oct  9 16:23 SRR2589044_2.fastq.gz
-rw-rw-r-- 1 dcuser dcuser 129138426 Oct  9 16:20 SRR2589044_1.fastq.gz
-rw-rw-r-- 1 dcuser dcuser  97578370 Oct  9 18:40 SRR2589044_1.trim.fastq.gz
-rw-rw-r-- 1 dcuser dcuser  95396892 Oct  9 18:40 SRR2589044_2.trim.fastq.gz
-rw-rw-r-- 1 dcuser dcuser  18322107 Oct  9 18:40 SRR2589044_1un.trim.fastq.gz
-rw-rw-r-- 1 dcuser dcuser    277272 Oct  9 18:40 SRR2589044_2un.trim.fastq.gz
```
