### PR TITLE
Patch 1 - Fix typo, add spaces after commands, add -p

### DIFF
--- a/_episodes/00-quality-control.md
+++ b/_episodes/00-quality-control.md
@@ -55,7 +55,7 @@ curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/004/SRR2589044/SRR2589044_2.fa
 curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/003/SRR2584863/SRR2584863_1.fastq.gz
 curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/003/SRR2584863/SRR2584863_2.fastq.gz
 curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_1.fastq.gz
-curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_2.fastq.gz
+curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_2.fastq.gz 
 ~~~
 {: .bash}
 

--- a/_episodes/00-quality-control.md
+++ b/_episodes/00-quality-control.md
@@ -62,7 +62,7 @@ curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_2.fa
 The data comes in a compressed format, which is why there is a `.gz` at the end of the file names. This makes it faster to transfer, and allows it to take up less space on our computer. Let's unzip one of the files so that we can look at the fastq format.
 
 ~~~
-gunzip SRR2584863_1.fastq.gz
+gunzip SRR2584863_1.fastq.gz 
 ~~~
 {: .bash}
 
@@ -88,7 +88,7 @@ We can view the first complete read in one of the files our dataset by using `he
 the first four lines. 
 
 ~~~
-$ head -n 4 SRR2584863_1.fastq
+$ head -n 4 SRR2584863_1.fastq 
 ~~~
 {: .bash}
 
@@ -209,7 +209,7 @@ Here, we see positions within the read in which the boxes span a much wider rang
 We will now assess the quality of the reads that we downloaded. First, make sure you're still in the `untrimmed_fastq` directory
 
 ~~~
-$ cd ~/dc_workshop/data/untrimmed_fastq/
+$ cd ~/dc_workshop/data/untrimmed_fastq/ 
 ~~~
 {: .bash}
 
@@ -310,7 +310,7 @@ output files into a new directory within our `results/` directory.
 ~~~
 $ mkdir -p ~/dc_workshop/results/fastqc_untrimmed_reads
 $ mv *.zip ~/dc_workshop/results/fastqc_untrimmed_reads/
-$ mv *.html ~/dc_workshop/results/fastqc_untrimmed_reads/
+$ mv *.html ~/dc_workshop/results/fastqc_untrimmed_reads/ 
 ~~~
 {: .bash}
 
@@ -318,7 +318,7 @@ Now we can navigate into this results directory and do some closer
 inspection of our output files.
 
 ~~~
-$ cd ~/dc_workshop/results/fastqc_untrimmed_reads/
+$ cd ~/dc_workshop/results/fastqc_untrimmed_reads/ 
 ~~~
 {: .bash}
 
@@ -328,7 +328,7 @@ If we were working on our local computers, we'd be able to display each of these
 HTML files as a webpage: 
  
 ~~~
-$ open SRR2584863_1_fastqc.html
+$ open SRR2584863_1_fastqc.html 
 ~~~
 {: .bash}
 
@@ -354,7 +354,7 @@ tab in your terminal program (you can use the pull down menu at the
 top of your screen or the Cmd+t keyboard shortcut) and type: 
 
 ~~~
-$ mkdir ~/Desktop/fastqc_html
+$ mkdir ~/Desktop/fastqc_html 
 ~~~
 {: .bash}
 
@@ -394,8 +394,8 @@ SRR2589044_2_fastqc.html                      100%  251KB 592.2KB/s   00:00
 Now we can go to our new directory and open the HTML files. 
 
 ~~~
-$ cd ~/Desktop/fastqc_html/
-$ open *.html
+$ cd ~/Desktop/fastqc_html/ 
+$ open *.html 
 ~~~
 {: .bash}
 

--- a/_episodes/00-quality-control.md
+++ b/_episodes/00-quality-control.md
@@ -283,7 +283,7 @@ The FastQC program has created several new files within our
 `data/untrimmed_fastq/` directory. 
 
 ~~~
-$ ls
+$ ls 
 ~~~
 {: .bash}
 
@@ -308,8 +308,8 @@ will move these
 output files into a new directory within our `results/` directory.
 
 ~~~
-$ mkdir -p ~/dc_workshop/results/fastqc_untrimmed_reads
-$ mv *.zip ~/dc_workshop/results/fastqc_untrimmed_reads/
+$ mkdir -p ~/dc_workshop/results/fastqc_untrimmed_reads 
+$ mv *.zip ~/dc_workshop/results/fastqc_untrimmed_reads/ 
 $ mv *.html ~/dc_workshop/results/fastqc_untrimmed_reads/ 
 ~~~
 {: .bash}
@@ -354,7 +354,7 @@ tab in your terminal program (you can use the pull down menu at the
 top of your screen or the Cmd+t keyboard shortcut) and type: 
 
 ~~~
-$ mkdir ~/Desktop/fastqc_html 
+$ mkdir -p ~/Desktop/fastqc_html 
 ~~~
 {: .bash}
 
@@ -437,8 +437,8 @@ in your terminal program that is connected to your AWS instance
 our results subdirectory.   
 
 ~~~
-$ cd ~/dc_workshop/results/fastqc_untrimmed_reads/
-$ ls
+$ cd ~/dc_workshop/results/fastqc_untrimmed_reads/ 
+$ ls 
 ~~~
 {: .bash}
 
@@ -457,7 +457,7 @@ to decompress these files. Let's try doing them all at once using a
 wildcard.
 
 ~~~
-$ unzip *.zip
+$ unzip *.zip 
 ~~~
 {: .bash}
 
@@ -550,7 +550,7 @@ but now we also have a new directory for each of our samples. We can
 see for sure that it's a directory if we use the `-F` flag for `ls`. 
 
 ~~~
-$ ls -F
+$ ls -F 
 ~~~
 {: .bash}
 
@@ -567,7 +567,7 @@ SRR2584863_2_fastqc.zip   SRR2584866_2_fastqc.zip   SRR2589044_2_fastqc.zip
 Let's see what files are present within one of these output directories.
 
 ~~~
-$ ls -F SRR2584863_1_fastqc/
+$ ls -F SRR2584863_1_fastqc/ 
 ~~~
 {: .bash}
 
@@ -579,7 +579,7 @@ fastqc_data.txt  fastqc.fo  fastqc_report.html	Icons/	Images/  summary.txt
 Use `less` to preview the `summary.txt` file for this sample. 
 
 ~~~
-$ less SRR2584863_1_fastqc/summary.txt
+$ less SRR2584863_1_fastqc/summary.txt 
 ~~~
 {: .bash}
 
@@ -599,7 +599,7 @@ WARN    Adapter Content SRR2584863_1.fastq
 {: .output}
 
 The summary file gives us a list of tests that FastQC ran, and tells
-us whether this sample passed, failed, or is borderline (`WARN`).
+us whether this sample passed, failed, or is borderline (`WARN`). Remember to quit from `less` you enter `q`.
 
 ## Documenting Our Work
 

--- a/_episodes/00-quality-control.md
+++ b/_episodes/00-quality-control.md
@@ -244,7 +244,7 @@ $ cd ~/dc_workshop/data/untrimmed_fastq/
 FastQC can accept multiple file names as input, and on both zipped and unzipped files, so we can use the \*.fastq* wildcard to run FastQC on all of the FASTQ files in this directory.
 
 ~~~
-$ fastqc *.fastq*
+$ fastqc *.fastq* 
 ~~~
 {: .bash}
 

--- a/_episodes/00-quality-control.md
+++ b/_episodes/00-quality-control.md
@@ -609,7 +609,7 @@ using the `cat` command. We'll call this `full_report.txt` and move
 it to `~/dc_workshop/docs`.
 
 ~~~
-$ cat */summary.txt > ~/dc_workshop/docs/fastqc_summaries.txt
+$ cat */summary.txt > ~/dc_workshop/docs/fastqc_summaries.txt 
 ~~~
 {: .bash}
 

--- a/_episodes/00-quality-control.md
+++ b/_episodes/00-quality-control.md
@@ -62,7 +62,7 @@ curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_2.fa
 The data comes in a compressed format, which is why there is a `.gz` at the end of the file names. This makes it faster to transfer, and allows it to take up less space on our computer. Let's unzip one of the files so that we can look at the fastq format.
 
 ~~~
-gunzip SRR2584863_1.fastq
+gunzip SRR2584863_1.fastq.gz
 ~~~
 {: .bash}
 

--- a/_episodes/02-variant_calling.md
+++ b/_episodes/02-variant_calling.md
@@ -254,7 +254,7 @@ $ vcfutils.pl varFilter results/bcf/SRR2584863_variants.vcf  > results/vcf/SRR25
 ## Explore the VCF format:
 
 ~~~
-$ less results/vcf/SRR2584863_final_variants.vcf
+$ less -S results/vcf/SRR2584863_final_variants.vcf
 ~~~
 {: .bash}
 

--- a/_episodes/02-variant_calling.md
+++ b/_episodes/02-variant_calling.md
@@ -254,7 +254,7 @@ $ vcfutils.pl varFilter results/bcf/SRR2584863_variants.vcf  > results/vcf/SRR25
 ## Explore the VCF format:
 
 ~~~
-$ less -S results/vcf/SRR2584863_final_variants.vcf
+$ less -S results/vcf/SRR2584866_final_variants.vcf
 ~~~
 {: .bash}
 


### PR DESCRIPTION
The biggest problem this PR fixes a typo in fix 00-quality-control.md. Previously, the `gunzip` command did not run correctly on the fastq file because it is gzipped.

I added a space after the last line of the command to download the raw data files so the command will run automatically instead of requiring learners to hit enter on that line. The last file takes 2-3 times longer to download than the other files, so getting stuck on it can hold someone back. I also added spaces behind other commands so they will run automatically when copy and pasted.

I added -p to some existing mkdir commands to be consist with other instances of this command.

I added -S to the less command and changed the file name in the variant calling portion of this lesson.

Also, my apologies for unhelpfully calling this branch patch-1.