### PR TITLE
remove indentation call out

### DIFF
--- a/_episodes/03-automation.md
+++ b/_episodes/03-automation.md
@@ -319,15 +319,6 @@ for fq in ~/dc_workshop/data/trimmed_fastq_small/*.fastq
 {: .bash}
 
 
-> ## Indentation
-> 
-> All of the statements within your `for` loop (i.e. everything after the `for` line and including the `done` line) 
-> need to be indented. This indicates to the shell interpretor that these statements are all part of the `for` loop
-> and should be done once per input.
-> 
-{: .callout}
-
-
 > ## Exercise
 > 
 > This is a good time to check that our script is assigning the FASTQ filename variables correctly. Save your script and run


### PR DESCRIPTION
Bash for loop _can_ be indented, but they do not  "need to be indented" as stated in this callout. indenting is useful for humans, but it is not necessary. 

This is not the first instance of a for loop in this lesson, so I think this is too late for a callout here. One could be added earlier, but I would suggest including something about one line versus for line for loops.
