### PR TITLE
[merge] Tr/auto exercises

### DIFF
--- a/_episodes/02-variant_calling.md
+++ b/_episodes/02-variant_calling.md
@@ -433,8 +433,27 @@ locations. That is good! If that wasn't the case, we should probably reconsider 
 
 Below the horizontal line, we can see all of the reads in our sample aligned with the reference genome. Only 
 positions where the called base differs from the reference are shown. You can use the arrow keys on your keyboard
-to scroll or type `?` for a help menu. Type `Ctrl^C` to exit `tview`. 
+to scroll or type `?` for a help menu. To navigate to a specific position, type `g`. A dialogue box will appear. In
+this box, type the name of the "chromosome" followed by a colon and the position of the variant you would like to view
+(e.g. for this sample, type `CP000819.1:50` to view the 50th base. Type `Ctrl^C` or `q` to exit `tview`. 
 
+> ## Exercise 
+> 
+> Visualize the alignment of the reads for our `SRR2584866` sample. What variant is present at 
+> position 4377265? What is the canonical nucleotide in that position? 
+> 
+>> ## Solution
+>> 
+>> ~~~
+>> $ samtools tview ~/dc_workshop/results/bam/SRR2584866.aligned.sorted.bam ~/dc_workshop/data/ref_genome/ecoli_rel606.fasta
+>> ~~~
+>> {: .bash}
+>> 
+>> Then type `g`. In the dialogue box, type `CP000819.1:4377265`. 
+>> `G` is the variant. `A` is canonical. This variant possibly changes the phenotype of this sample to hypermutable. It occurs
+>> in the gene *mutL*, which controls DNA mismatch repair.
+> {: .solution}
+> 
 
 ### Viewing with IGV
 

--- a/_episodes/03-automation.md
+++ b/_episodes/03-automation.md
@@ -435,107 +435,12 @@ $ bash run_variant_calling.sh
 {: .bash}
 
 
-> ## BWA variations
-> BWA is a software package for mapping low-divergent sequences 
-> against a large reference genome, such as the human genome, and 
-> it's freely available [here](http://bio-bwa.sourceforge.net). It 
-> consists of three algorithms: BWA-backtrack, BWA-SW and BWA-MEM, 
-> each being invoked with different sub-commands: `aln + samse + sampe` for BWA-backtrack, `bwasw` for BWA-SW and `mem` for the 
-> BWA-MEM algorithm. BWA-backtrack is designed for Illumina sequence reads up to 100bp, while the rest two are better fitted for 
-> longer sequences ranged from 70bp to 1Mbp. A general rule of thumb is to use `bwa mem` for reads longer than 70 bp, whereas 
-> `bwa aln` has a moderately higher mapping rate and a shorter run 
-> time for short reads (~36bp). You can find a more indepth discussion in the [bwa doc page](http://bio-bwa.sourceforge.net/bwa.shtml) as well as in this 
-> [blog post](http://crazyhottommy.blogspot.ca/2017/06/bwa-aln-or-bwa-mem-for-short-reads-36bp.html).
-> In this lesson we have been using the `aln` for performing the 
-> alignment, but the same process can be performed with `bwa mem` which doesn't require the creation of the index files. The 
-> process is modified starting from `mkdir` step, and omitting all directories relevant to the `.sai` index files, i.e.:
-> 
-> Create output paths for various intermediate and result files.
+> ## Exerecise
 >
-> ~~~
-> $ mkdir -p results/sam results/bam results/bcf results/vcf
-> ~~~
-> {: .bash}
->
-> Assign file names to variables
->
-> ~~~
-> $ fq=data/trimmed_fastq/${base}.fastq
-> $ sam=results/sam/${base}.aligned.sam
-> $ bam=results/bam/${base}.aligned.bam
-> $ sorted_bam=results/bam/${base}.aligned.sorted.bam
-> $ raw_bcf=results/bcf/${base}_raw.bcf
-> $ variants=results/bcf/${base}_variants.vcf
-> $ final_variants=results/vcf/${base}_final_variants.vcf  
-> ~~~
-> {: .bash}
->
-> Run the alignment
-> 
-> ~~~
-> $ bwa mem -M $genome $fq > $sam
-> ~~~
-> {: .bash}
-> 
-> As an exercise, try and change your existing script file, from using the `aln` method to the `mem` method.
-{: .callout}
-
-In the [previous lesson](http://www.datacarpentry.org/wrangling-genomics/02-variant_calling/) we mentioned that we were using small subsets of our
-trimmed FASTQ files to run our variant calling workflow, in the interests of time. The output files you now have in your 
-`dc_workshop/results` directory are based on the small sample FASTQ files (data from the `trimmed_fastq_small` directory). 
-We've also provided the result files from running the `run_variant_calling.sh` script on the full-sized trimmed FASTQ files. 
-Let's do a few comparisons.
-
-
-> ## Exercise (Novice)
-> 
-> How much larger are the full-sized trimmed FASTQ files than the small trimmed FASTQ files we just ran our variant calling
-> script on?
->
-> Hint: You can find a copy of the full-sized trimmed 
-> FASTQ files in the `~/.dc_sampledata_lite/solutions/wrangling-solutions/trimmed_fastq` directory.
-> 
-> > ## Solution
-> > 
-> > ~~~
-> > $ ls -lh ~/.dc_sampledata_lite/solutions/wrangling-solutions/trimmed_fastq
-> > ~~~
-> > {: .bash}
-> > 
-> > ~~~
-> > total 13G
-> > ~~~
-> > {: .output}
-> > 
-> > ~~~
-> > $ ls -lh ~/dc_workshop/data/trimmed_fastq_small
-> > ~~~
-> > {: .bash}
-> > 
-> > ~~~ 
-> > total 430M
-> > ~~~
-> > {: .output}
-> {: .solution}
-{: .challenge}
-
-> ## Exercise (Intermediate) **To Do: Update exercise with new data**
-> 
-> Vizualize the alignment of the reads for our `SRR098281.fastq_trim.fastq_small` sample. What variant is present at 
-> position 145? What is the canonical nucleotide in that position? 
-> 
->> ## Solution
->> 
->> ~~~
->> $ samtools tview ~/dc_workshop/results/bam/SRR098281.aligned.sorted.bam ~/dc_workshop/data/ref_genome/ecoli_rel606.fasta
->> ~~~
->> {: .bash}
->> 
->> `T` is the variant. `G` is canonical. 
-> {: .solution}
-> 
-> Now vizualize the alignment of the reads for the full-length trimmed FASTQ file for the SRR098281 sample. What 
-variants are present in position 145? 
+> The samples we just performed variant calling on are part of the long-term evolution experiment we introduced at the 
+> beginning of our variant calling workflow. From the metadata table, we know that SRR2589044 was from generation 5000,
+> SRR2584863 was from generation 15000, and SRR2584866 was from generation 50000. How did the number of mutations per sample change
+> over time? Examine the metadata table. What is one reason the number of mutations may have changed the way they did?
 > 
 > Hint: You can find a copy of the output files for the full-length trimmed FASTQ file variant calling in the 
 > `~/.dc_sampledata_lite/solutions/wrangling-solutions/variant_calling/` directory.
@@ -543,20 +448,26 @@ variants are present in position 145?
 >> ## Solution
 >> 
 >> ~~~
->> $ samtools tview ~/.dc_sampledata_lite/solutions/wrangling-solutions/variant_calling/bam/SRR098281.aligned.sorted.bam ~/dc_workshop/data/ref_genome/ecoli_rel606.fasta
+>> $ for infile in ~/dc_workshop/results/vcf/*_final_variants.vcf
+>> > do
+>> >     echo ${infile}
+>> >     grep -v "#" ${infile} | wc -l
+>> > done
 >> ~~~
 >> {: .bash}
 >> 
->> In the full-length file, `T` is still the only variant present at this location. 
+>> For SRR2589044 from generation 5000 there were 10 mutations, for SRR2584863 from generation 15000 there were 25 mutations, 
+>> and SRR2584866 from generation 766 mutations. In the last generation, a hypermutable phenotype had evolved, causing this
+>> strain to have more mutations. 
 > {: .solution}
 {: .challenge}
 
 
-> ## Bonus Exercise (Advanced)
+> ## Bonus Exercise
 > 
-> If you have time after completing the previous two exercises, use `run_variant_calling.sh` to run the variant calling pipeline 
+> If you have time after completing the previous exercise, use `run_variant_calling.sh` to run the variant calling pipeline 
 > on the full-sized trimmed FASTQ files. You should have a copy of these already in `~/dc_workshop/data/trimmed_fastq` but if 
-> you dont, there is a copy in `~/.dc_sampledata_lite/solutions/wrangling-solutions/trimmed_fastq`.
+> you dont, there is a copy in `~/.dc_sampledata_lite/solutions/wrangling-solutions/trimmed_fastq`. Does the number of variants change per sample?
 {: .challenge} 
 
 

--- a/_episodes/03-automation.md
+++ b/_episodes/03-automation.md
@@ -435,9 +435,9 @@ $ bash run_variant_calling.sh
 {: .bash}
 
 
-> ## Exerecise
+> ## Exercise
 >
-> The samples we just performed variant calling on are part of the long-term evolution experiment we introduced at the 
+> The samples we just performed variant calling on are part of the long-term evolution experiment introduced at the 
 > beginning of our variant calling workflow. From the metadata table, we know that SRR2589044 was from generation 5000,
 > SRR2584863 was from generation 15000, and SRR2584866 was from generation 50000. How did the number of mutations per sample change
 > over time? Examine the metadata table. What is one reason the number of mutations may have changed the way they did?
@@ -467,7 +467,7 @@ $ bash run_variant_calling.sh
 > 
 > If you have time after completing the previous exercise, use `run_variant_calling.sh` to run the variant calling pipeline 
 > on the full-sized trimmed FASTQ files. You should have a copy of these already in `~/dc_workshop/data/trimmed_fastq` but if 
-> you dont, there is a copy in `~/.dc_sampledata_lite/solutions/wrangling-solutions/trimmed_fastq`. Does the number of variants change per sample?
+> you don't, there is a copy in `~/.dc_sampledata_lite/solutions/wrangling-solutions/trimmed_fastq`. Does the number of variants change per sample?
 {: .challenge} 
 
 


### PR DESCRIPTION
These changes update the exercises at the end of 02-variant-calling and 03-automation. They are more biologically relevant, and tie in the hypermutability story. I moved one of the exercises from 03 into 02, because I felt like it fit better there. 

@ryanpeek @bluegenes @raynamharris @jessicamizzi ready for review & feedback or merge!